### PR TITLE
Fix style of links in the Header component

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -15,6 +15,21 @@ const StyledHeader = styled.div`
   height: ${props => SIZES[props.size]}px;
   border-top-left-radius: ${spacing.borderRadius.default}px;
   border-top-right-radius: ${spacing.borderRadius.default}px;
+
+  // Links within Header
+  a {
+    opacity: 0.8;
+  }
+
+  a:hover {
+    opacity: 1;
+  }
+
+  // Heading/Paragraph hover
+  a:hover span,
+  a:hover div {
+    text-decoration: underline;
+  }
 `
 
 export const Header = props => {


### PR DESCRIPTION
If links are placed within header, we need to style them according to our design system: a bit of hover opacity + text-decoration on span/divs, which are used in the Heading/Paragraph components.