### PR TITLE
Better Heading & Paragraph props and titles

### DIFF
--- a/src/components/Heading.stories.js
+++ b/src/components/Heading.stories.js
@@ -8,7 +8,7 @@ export default {
   },
 }
 
-export const Heading1 = () => (
+export const Big = () => (
   <div>
     <Heading size="big">Heading 1 / Left </Heading>
     <Heading size="big" align="center">
@@ -20,7 +20,7 @@ export const Heading1 = () => (
   </div>
 )
 
-export const Heading2 = () => (
+export const Medium = () => (
   <div>
     <Heading size="medium">Heading 2 / Left</Heading>
     <Heading size="medium" align="center">

--- a/src/components/Paragraph.js
+++ b/src/components/Paragraph.js
@@ -17,8 +17,8 @@ const ALIGNMENT = {
 }
 
 const StyledParagraph = styled.span`
-  display: ${props => (props.isInline ? 'inline' : 'inline-block')};
-  padding-bottom: ${spacing.padding.tiny}px;
+  display: ${props => (props.inline ? 'inline' : 'block')};
+  padding-bottom: ${props => (props.padded ? spacing.padding.tiny : 0)}px;
   letter-spacing: normal;
   font-weight: ${props => typography.sizes[SIZES[props.size]].weight};
   font-size: ${props => typography.sizes[SIZES[props.size]].size}px;
@@ -45,12 +45,17 @@ Paragraph.propTypes = {
   /**
    * Whether it is inline
    */
-  isInline: PropTypes.bool,
+  inline: PropTypes.bool,
+  /**
+   * Whether it is padded
+   */
+  padded: PropTypes.bool,
 }
 
 Paragraph.defaultProps = {
   size: 'medium',
   color: 'jetBlack',
   align: ALIGNMENT.left,
-  isInline: false,
+  inline: false,
+  padded: true,
 }

--- a/src/components/Paragraph.stories.js
+++ b/src/components/Paragraph.stories.js
@@ -8,66 +8,50 @@ export default {
   },
 }
 
-export const Paragraph1 = () => (
+export const Big = () => (
   <div>
-    <div>
-      <Paragraph size="big">
-        We&apos;re here every step of the way making sure you and your team
-        deliver standout customer experiences easily with Groove.
-      </Paragraph>
-    </div>
-    <div>
-      <Paragraph size="big" align="center">
-        We&apos;re here every step of the way making sure you and your team
-        deliver standout customer experiences easily with Groove.
-      </Paragraph>
-    </div>
-    <div>
-      <Paragraph size="big" align="right">
-        We&apos;re here every step of the way making sure you and your team
-        deliver standout customer experiences easily with Groove.
-      </Paragraph>
-    </div>
-  </div>
-)
-
-export const Paragraph2 = () => (
-  <div>
-    <div>
-      <Paragraph size="medium">
-        We&apos;re here every step of the way making sure you and your team
-        deliver standout customer experiences easily with Groove.
-      </Paragraph>
-    </div>
-    <div>
-      <Paragraph size="medium" align="center">
-        We&apos;re here every step of the way making sure you and your team
-        deliver standout customer experiences easily with Groove.
-      </Paragraph>
-    </div>
-    <div>
-      <Paragraph size="medium" align="right">
-        We&apos;re here every step of the way making sure you and your team
-        deliver standout customer experiences easily with Groove.
-      </Paragraph>
-    </div>
-  </div>
-)
-
-export const Paragraph3 = () => (
-  <div>
-    <Paragraph size="small">
+    <Paragraph size="big">
+      We&apos;re here every step of the way making sure you and your team
+      deliver standout customer experiences easily with Groove.
+    </Paragraph>
+    <Paragraph size="big" align="center">
+      We&apos;re here every step of the way making sure you and your team
+      deliver standout customer experiences easily with Groove.
+    </Paragraph>
+    <Paragraph size="big" align="right">
       We&apos;re here every step of the way making sure you and your team
       deliver standout customer experiences easily with Groove.
     </Paragraph>
   </div>
 )
 
-export const Paragraph4 = () => (
+export const Medium = () => (
   <div>
-    <Paragraph size="tiny">
+    <Paragraph size="medium">
+      We&apos;re here every step of the way making sure you and your team
+      deliver standout customer experiences easily with Groove.
+    </Paragraph>
+    <Paragraph size="medium" align="center">
+      We&apos;re here every step of the way making sure you and your team
+      deliver standout customer experiences easily with Groove.
+    </Paragraph>
+    <Paragraph size="medium" align="right">
       We&apos;re here every step of the way making sure you and your team
       deliver standout customer experiences easily with Groove.
     </Paragraph>
   </div>
+)
+
+export const Small = () => (
+  <Paragraph size="small">
+    We&apos;re here every step of the way making sure you and your team deliver
+    standout customer experiences easily with Groove.
+  </Paragraph>
+)
+
+export const Tiny = () => (
+  <Paragraph size="tiny">
+    We&apos;re here every step of the way making sure you and your team deliver
+    standout customer experiences easily with Groove.
+  </Paragraph>
 )

--- a/src/components/shared/styles.js
+++ b/src/components/shared/styles.js
@@ -87,7 +87,7 @@ export const spacing = {
   borderRadius: {
     small: 2,
     medium: 4,
-    large: 10,
+    big: 10,
     default: 4,
   },
 }


### PR DESCRIPTION
- Rename Paragraph and Heading component stories
- Rename `Paragraph#isInline` to `Paragraph#inline` to match other boolean props
- Make Paragraph component either inline or block
- Add `Paragraph#padded` prop
- Rename `borderRadius#large` to `borderRadius#big` for consistency