### PR TITLE
Add the emotion plugin to the babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,6 +6,7 @@ module.exports = api => {
     plugins: [
       '@babel/plugin-proposal-object-rest-spread',
       '@babel/transform-runtime',
+      'emotion',
     ],
     env: {
       test: {


### PR DESCRIPTION
This commit allows emotion to work (more) properly. Specifically, this fixes an issue with nesting styled component references in emotion.