### PR TITLE
Extrinsically size components

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -8,6 +8,7 @@ import { icons } from './shared/icons'
 import { Icon, ICON_SIZES } from './Icon'
 
 const base = css`
+  align-self: flex-start;
   background-color: ${color.paperWhite};
   border-radius: ${spacing.borderRadius.default}px;
   border-style: solid;

--- a/src/components/Button.stories.js
+++ b/src/components/Button.stories.js
@@ -3,6 +3,7 @@ import styled from '@emotion/styled'
 import { Button } from './Button'
 import { FlexContainer } from './FlexContainer'
 import { FlexItem } from './FlexItem'
+import { Field } from './Forms/Field'
 import { color, spacing } from './shared/styles'
 
 export default {
@@ -91,4 +92,16 @@ export const Loading = () => (
       <Button icon="arrowLeft" loading />
     </FlexItem>
   </FlexContainer>
+)
+
+export const FormField = () => (
+  <Field>
+    <Button>Submit</Button>
+  </Field>
+)
+
+export const FormFieldStretched = () => (
+  <Field>
+    <Button stretched>Submit</Button>
+  </Field>
 )

--- a/src/components/Forms/CheckRadioBase.js
+++ b/src/components/Forms/CheckRadioBase.js
@@ -5,10 +5,16 @@ import React from 'react'
 import styled from '@emotion/styled'
 import { color, spacing } from '../shared/styles'
 
-export const StyledLabel = styled.label`
+const Container = styled.div`
   display: flex;
   flex-direction: row;
+`
+
+const StyledLabel = styled.label`
+  display: inline-flex;
+  flex-direction: row;
   align-items: flex-start;
+  align-self: flex-start;
 `
 
 export const HiddenElement = styled.input`
@@ -38,10 +44,16 @@ export const ElementContainer = styled.div`
 `
 
 const StyledGroupContainer = styled.div`
-  ${StyledLabel} {
-    margin-bottom: ${spacing.padding.mini}px;
+  display: flex;
+  flex-direction: ${({ direction }) =>
+    direction === 'horizontal' ? 'row' : 'column'};
+  ${Container} {
+    margin: ${({ direction }) =>
+      direction === 'horizontal'
+        ? `0 ${spacing.padding.medium}px 0 0`
+        : `0 0 ${spacing.padding.mini}px 0`};
     &:last-child {
-      margin-bottom: 0;
+      margin: 0;
     }
   }
 `
@@ -59,11 +71,12 @@ export const CheckRadioGroup = ({
   contextValue,
   options,
   optionsMapFn,
+  direction,
   children,
 }) => {
   return (
     <GroupContext.Provider value={contextValue}>
-      <StyledGroupContainer>
+      <StyledGroupContainer direction={direction}>
         {children || optionsMapFn(options)}
       </StyledGroupContainer>
     </GroupContext.Provider>
@@ -81,18 +94,20 @@ export const CheckRadioBase = ({
   ...rest
 }) => {
   return (
-    <StyledLabel className={className}>
-      <ElementContainer>
-        <HiddenElement
-          type="checkbox"
-          checked={checked}
-          name={name}
-          onChange={onChange}
-          {...rest}
-        />
-        <StyledComponent>{checked && children}</StyledComponent>
-      </ElementContainer>
-      {label}
-    </StyledLabel>
+    <Container>
+      <StyledLabel className={className}>
+        <ElementContainer>
+          <HiddenElement
+            type="checkbox"
+            checked={checked}
+            name={name}
+            onChange={onChange}
+            {...rest}
+          />
+          <StyledComponent>{checked && children}</StyledComponent>
+        </ElementContainer>
+        {label}
+      </StyledLabel>
+    </Container>
   )
 }

--- a/src/components/Forms/Checkbox.js
+++ b/src/components/Forms/Checkbox.js
@@ -51,6 +51,7 @@ export const CheckboxGroup = ({
   value: controlledValues,
   onChange,
   options,
+  direction,
   children,
 }) => {
   const [selectedValues, setSelectedValues] = useState(controlledValues || {})
@@ -81,6 +82,7 @@ export const CheckboxGroup = ({
       }}
       options={options}
       optionsMapFn={renderOptions}
+      direction={direction}
     >
       {children}
     </CheckRadioGroup>
@@ -110,6 +112,10 @@ CheckboxGroup.propTypes = {
    * Handler function for any checkbox in group, has signature (event, { groupName: string, groupValues: { name: bool }) => {}
    */
   onChange: PropTypes.func,
+  /**
+   * Direction of checkboxes in group
+   */
+  direction: PropTypes.oneOf(['horizontal', 'vertical']),
 }
 
 CheckboxGroup.defaultProps = {
@@ -117,6 +123,7 @@ CheckboxGroup.defaultProps = {
   options: undefined,
   value: undefined,
   onChange: undefined,
+  direction: 'vertical',
 }
 
 export const CheckboxOption = ({

--- a/src/components/Forms/Checkbox.stories.js
+++ b/src/components/Forms/Checkbox.stories.js
@@ -37,6 +37,20 @@ export const Group = () => {
   )
 }
 
+export const HorizontalGroup = () => {
+  return (
+    <Field>
+      <CheckboxGroup direction="horizontal">
+        <CheckboxOption name="leon" label="Leon Kowalski" />
+        <CheckboxOption name="pris" label="Pris Stratton" />
+        <CheckboxOption name="roy" label="Roy Batty" />
+        <CheckboxOption name="zhora" label="Zhora Salome" />
+        <CheckboxOption name="deckard" label="Rick Deckard" />
+      </CheckboxGroup>
+    </Field>
+  )
+}
+
 export const OptionsParam = () => {
   return (
     <Field>

--- a/src/components/Forms/Field.js
+++ b/src/components/Forms/Field.js
@@ -17,7 +17,6 @@ const FieldContainer = styled.div`
 const ChildrenContainer = styled.div`
   display: inline-flex;
   flex-direction: column;
-  align-items: flex-start;
 `
 
 const ValidationIcon = styled(Icon)`

--- a/src/components/Forms/Input.js
+++ b/src/components/Forms/Input.js
@@ -45,7 +45,6 @@ const ButtonWrapper = styled.div`
 `
 
 export const Input = ({
-  stretched,
   label: labelText,
   icon,
   iconPosition,
@@ -98,7 +97,7 @@ export const Input = ({
   }, [onIconClick])
 
   return (
-    <Label stretched={stretched} text={labelText}>
+    <Label text={labelText}>
       <input
         size={labelText ? labelText.length : 0}
         placeholder={labelText}
@@ -126,10 +125,6 @@ Input.propTypes = {
    */
   label: PropTypes.string.isRequired,
   /**
-   * Stretch width to fill container
-   */
-  stretched: PropTypes.bool,
-  /**
    * Specify icon name
    */
   icon: PropTypes.string,
@@ -149,7 +144,6 @@ Input.propTypes = {
 }
 
 Input.defaultProps = {
-  stretched: true,
   icon: null,
   iconPosition: 'right',
   onIconClick: null,

--- a/src/components/Forms/Input.stories.js
+++ b/src/components/Forms/Input.stories.js
@@ -1,4 +1,6 @@
+/** @jsx jsx */
 import React from 'react'
+import { jsx, css } from '@emotion/core'
 import { Input } from './Input'
 import { Field } from './Field'
 import { Button } from '../Button'
@@ -28,9 +30,13 @@ export const Basic = () => (
   </React.Fragment>
 )
 
-export const Unstretched = () => (
-  <Field>
-    <Input label="Replicant's Name" type="text" name="name" stretched={false} />
+export const Sized = () => (
+  <Field
+    css={css`
+      max-width: 200px;
+    `}
+  >
+    <Input label="Replicant's Name" type="text" name="name" />
   </Field>
 )
 

--- a/src/components/Forms/Label.js
+++ b/src/components/Forms/Label.js
@@ -2,17 +2,19 @@
 
 import PropTypes from 'prop-types'
 import { css, jsx } from '@emotion/core'
-import { stretchedStyle } from '../shared/forms'
 
 const base = css`
-  display: inline-flex;
+  align-items: stretch;
+  display: flex;
+  flex-wrap: wrap;
   position: relative;
+  width: 100%;
 `
 
-export const Label = ({ stretched, children, text, ...rest }) => {
+export const Label = ({ children, text, inline, ...rest }) => {
   return (
     // eslint-disable-next-line jsx-a11y/label-has-associated-control
-    <label css={[base, stretched && stretchedStyle]} {...rest}>
+    <label css={base} {...rest}>
       <span css={{ display: 'none' }}>{text}</span>
       {children}
     </label>
@@ -24,12 +26,4 @@ Label.propTypes = {
    * Text of label (invisible for now, as all components use placeholder labels)
    */
   text: PropTypes.string.isRequired,
-  /**
-   * Stretch width to fill container
-   */
-  stretched: PropTypes.bool,
-}
-
-Label.defaultProps = {
-  stretched: false,
 }

--- a/src/components/Forms/Radio.js
+++ b/src/components/Forms/Radio.js
@@ -50,6 +50,7 @@ export const RadioGroup = ({
   value: controlledValue,
   onChange,
   options,
+  direction,
   children,
 }) => {
   const [selectedValue, setSelectedValue] = useState(controlledValue)
@@ -73,6 +74,7 @@ export const RadioGroup = ({
       }}
       options={options}
       optionsMapFn={renderOptions}
+      direction={direction}
     >
       {children}
     </CheckRadioGroup>
@@ -102,6 +104,10 @@ RadioGroup.propTypes = {
    * Handler function with signature (event, { groupName: string, value: string }) => {}
    */
   onChange: PropTypes.func,
+  /**
+   * Direction of radio options in group
+   */
+  direction: PropTypes.oneOf(['horizontal', 'vertical']),
 }
 
 RadioGroup.defaultProps = {
@@ -109,6 +115,7 @@ RadioGroup.defaultProps = {
   options: undefined,
   value: undefined,
   onChange: undefined,
+  direction: 'vertical',
 }
 
 export const RadioOption = ({

--- a/src/components/Forms/Radio.stories.js
+++ b/src/components/Forms/Radio.stories.js
@@ -25,6 +25,20 @@ export const Basic = () => {
   )
 }
 
+export const Horizontal = () => {
+  return (
+    <Field>
+      <RadioGroup name="replicantBasic" value="" direction="horizontal">
+        <RadioOption value="leon" label="Leon Kowalski" />
+        <RadioOption value="pris" label="Pris Stratton" />
+        <RadioOption value="roy" label="Roy Batty" />
+        <RadioOption value="zhora" label="Zhora Salome" />
+        <RadioOption value="deckard" label="Rick Deckard" />
+      </RadioGroup>
+    </Field>
+  )
+}
+
 export const OptionsParam = () => {
   return (
     <Field>

--- a/src/components/Forms/Select.js
+++ b/src/components/Forms/Select.js
@@ -14,12 +14,9 @@ import {
 import { Icon, ICON_SIZES } from '../Icon'
 
 const wrapper = css`
+  display: flex;
+  flex: 1 1 0%;
   position: relative;
-  display: inline-flex;
-`
-
-const stretch = css`
-  width: 100%;
 `
 
 const selectBox = css`
@@ -44,7 +41,6 @@ const arrow = css`
 
 export const Select = ({
   value: controlledValue = '',
-  stretched,
   label: labelText,
   onChange,
   options,
@@ -74,8 +70,8 @@ export const Select = ({
   // reason. On first render, it doesn't render the label option that is added
   // below. We need to figure _why_ SSR is ignoring this on first render.
   return (
-    <Label stretched={stretched} text={labelText}>
-      <div css={[wrapper, stretched && stretch]}>
+    <Label text={labelText}>
+      <div css={wrapper}>
         <select
           {...rest}
           css={classes}
@@ -112,10 +108,6 @@ Select.propTypes = {
    */
   label: PropTypes.string.isRequired,
   /**
-   * Stretch width to fill container
-   */
-  stretched: PropTypes.bool,
-  /**
    * Array of options matching the shape {key: 'string', value: 'string', label: 'string'}. You can either pass this array as a prop, or simply render option elements as children of this component. Children take precendence over this prop.
    */
   options: PropTypes.arrayOf(
@@ -128,6 +120,5 @@ Select.propTypes = {
 }
 
 Select.defaultProps = {
-  stretched: true,
   options: null,
 }

--- a/src/components/Forms/Select.stories.js
+++ b/src/components/Forms/Select.stories.js
@@ -24,23 +24,6 @@ export const Basic = () => (
   </Field>
 )
 
-export const Unstretched = () => (
-  <Field>
-    <Select
-      label="Select Replicant…"
-      name="replicant"
-      value=""
-      stretched={false}
-    >
-      <option value="leon">Leon Kowalski</option>
-      <option value="pris">Pris Stratton</option>
-      <option value="roy">Roy Batty</option>
-      <option value="zhora">Zhora Salome</option>
-      <option value="deckard">Rick Deckard</option>
-    </Select>
-  </Field>
-)
-
 export const OptionsParam = () => (
   <Field>
     <Select

--- a/src/components/Forms/TextArea.js
+++ b/src/components/Forms/TextArea.js
@@ -14,7 +14,7 @@ const multiLineStyle = css`
   padding: 13px ${spacing.padding.small}px;
 `
 
-export const TextArea = ({ stretched, label: labelText, ...rest }) => {
+export const TextArea = ({ label: labelText, ...rest }) => {
   const fieldCtx = useContext(FieldContext)
   const classes = [
     baseStyle,
@@ -22,7 +22,7 @@ export const TextArea = ({ stretched, label: labelText, ...rest }) => {
     getValidationStateStyle(fieldCtx.validationState),
   ]
   return (
-    <Label stretched={stretched} text={labelText}>
+    <Label text={labelText}>
       <textarea {...rest} css={[classes]} placeholder={labelText} />
     </Label>
   )
@@ -33,12 +33,4 @@ TextArea.propTypes = {
    * Label text (also wraps Input in Label component)
    */
   label: PropTypes.string.isRequired,
-  /**
-   * Stretch width to fill container
-   */
-  stretched: PropTypes.bool,
-}
-
-TextArea.defaultProps = {
-  stretched: true,
 }

--- a/src/components/Forms/TextArea.stories.js
+++ b/src/components/Forms/TextArea.stories.js
@@ -15,12 +15,6 @@ export const Basic = () => (
   </Field>
 )
 
-export const Unstretched = () => (
-  <Field>
-    <TextArea label="Replicant's Name" name="bio" stretched={false} rows={10} />
-  </Field>
-)
-
 export const Validation = () => {
   const [validationState, setValidationState] = useState('error')
   const handleChange = e => {

--- a/src/components/shared/forms.js
+++ b/src/components/shared/forms.js
@@ -7,7 +7,9 @@ export const baseStyle = css`
   border: 1px solid ${color.metalGrey};
   border-radius: ${spacing.borderRadius.default}px;
   color: ${color.jetBlack};
+  flex: 1 1 0%;
   font-size: ${forms.typography.small.size}px;
+  min-width: 0;
   padding: 0 ${spacing.padding.small}px;
   width: 100%;
   ::placeholder {


### PR DESCRIPTION
This commit refactors out the concept of "stretched" for most of our
components. This prop started on button (where it is actually useful),
but then ended up being used too much. Most components should simply
fill the width of the container they are giving, thus separating the
concerns of layout and display. This way, the user of can set the size
of the component (and the layout) by simply constraining the width
through whatever layout means they feel work best (e.g. flexbox, fixed
widths, etc). This commit also introduces horizontal checkbox and radio
groups, as they have some specfic layout styling that we want to
preserve, even when allowing the user to determine primary layout.