### PR TITLE
Forward refs in form components

### DIFF
--- a/src/components/Forms/Input.js
+++ b/src/components/Forms/Input.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import { useContext, useCallback } from 'react'
+import React, { useContext, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { jsx, css } from '@emotion/core'
 import styled from '@emotion/styled'
@@ -43,81 +43,88 @@ const ButtonWrapper = styled.div`
     `}
   }
 `
+export const Input = React.forwardRef(
+  (
+    {
+      label: labelText,
+      icon,
+      iconPosition,
+      onIconClick,
+      button,
+      buttonPosition,
+      ...rest
+    },
+    ref
+  ) => {
+    const fieldCtx = useContext(FieldContext)
 
-export const Input = ({
-  label: labelText,
-  icon,
-  iconPosition,
-  onIconClick,
-  button,
-  buttonPosition,
-  ...rest
-}) => {
-  const fieldCtx = useContext(FieldContext)
+    const classes = [
+      baseStyle,
+      singleLineStyle,
+      getValidationStateStyle(fieldCtx.validationState),
+    ]
 
-  const classes = [
-    baseStyle,
-    singleLineStyle,
-    getValidationStateStyle(fieldCtx.validationState),
-  ]
+    const iconInputStyle = css`
+      &:focus ~ svg > path {
+        fill: ${color.primary};
+      }
+      padding: 0
+        ${iconPosition === 'right'
+          ? spacing.padding.big
+          : spacing.padding.small}px
+        0
+        ${iconPosition === 'left'
+          ? spacing.padding.big
+          : spacing.padding.small}px;
+    `
 
-  const iconInputStyle = css`
-    &:focus ~ svg > path {
-      fill: ${color.primary};
+    const buttonInputStyle = css`
+      padding: 0
+        ${buttonPosition === 'right'
+          ? spacing.padding.big + spacing.padding.small
+          : spacing.padding.small}px
+        0
+        ${buttonPosition === 'left'
+          ? spacing.padding.big + spacing.padding.small
+          : spacing.padding.small}px;
+    `
+
+    if (icon) {
+      classes.push(iconInputStyle)
+    } else if (button) {
+      classes.push(buttonInputStyle)
     }
-    padding: 0
-      ${iconPosition === 'right'
-        ? spacing.padding.big
-        : spacing.padding.small}px
-      0
-      ${iconPosition === 'left' ? spacing.padding.big : spacing.padding.small}px;
-  `
 
-  const buttonInputStyle = css`
-    padding: 0
-      ${buttonPosition === 'right'
-        ? spacing.padding.big + spacing.padding.small
-        : spacing.padding.small}px
-      0
-      ${buttonPosition === 'left'
-        ? spacing.padding.big + spacing.padding.small
-        : spacing.padding.small}px;
-  `
+    const handleIconClick = useCallback(() => {
+      if (onIconClick) {
+        onIconClick()
+      }
+    }, [onIconClick])
 
-  if (icon) {
-    classes.push(iconInputStyle)
-  } else if (button) {
-    classes.push(buttonInputStyle)
-  }
-
-  const handleIconClick = useCallback(() => {
-    if (onIconClick) {
-      onIconClick()
-    }
-  }, [onIconClick])
-
-  return (
-    <Label text={labelText}>
-      <input
-        size={labelText ? labelText.length : 0}
-        placeholder={labelText}
-        css={[classes]}
-        {...rest}
-      />
-      {icon && !button && (
-        <StyledIcon
-          onClick={onIconClick ? handleIconClick : undefined}
-          icon={icon}
-          position={iconPosition}
-          color="metalGrey"
+    return (
+      <Label text={labelText}>
+        <input
+          size={labelText ? labelText.length : 0}
+          placeholder={labelText}
+          css={[classes]}
+          {...rest}
+          ref={ref}
         />
-      )}
-      {button && !icon && (
-        <ButtonWrapper position={buttonPosition}>{button}</ButtonWrapper>
-      )}
-    </Label>
-  )
-}
+        {icon && !button && (
+          <StyledIcon
+            onClick={onIconClick ? handleIconClick : undefined}
+            icon={icon}
+            position={iconPosition}
+            color="metalGrey"
+          />
+        )}
+        {button && !icon && (
+          <ButtonWrapper position={buttonPosition}>{button}</ButtonWrapper>
+        )}
+      </Label>
+    )
+  }
+)
 
 Input.propTypes = {
   /**

--- a/src/components/Forms/Select.js
+++ b/src/components/Forms/Select.js
@@ -39,68 +39,74 @@ const arrow = css`
 // empty string for the purposes of setting values and determining if the
 // label is still selected.
 
-export const Select = ({
-  value: controlledValue = '',
-  label: labelText,
-  onChange,
-  options,
-  children,
-  ...rest
-}) => {
-  const fieldCtx = useContext(FieldContext)
-  const classes = [
-    baseStyle,
-    singleLineStyle,
-    selectBox,
-    getValidationStateStyle(fieldCtx.validationState),
-  ]
-  const [selectedValue, setSelectedValue] = useState(controlledValue)
-  useEffect(() => {
-    setSelectedValue(controlledValue || '')
-  }, [controlledValue, options, children])
+export const Select = React.forwardRef(
+  (
+    {
+      value: controlledValue = '',
+      label: labelText,
+      onChange,
+      options,
+      children,
+      ...rest
+    },
+    ref
+  ) => {
+    const fieldCtx = useContext(FieldContext)
+    const classes = [
+      baseStyle,
+      singleLineStyle,
+      selectBox,
+      getValidationStateStyle(fieldCtx.validationState),
+    ]
+    const [selectedValue, setSelectedValue] = useState(controlledValue)
+    useEffect(() => {
+      setSelectedValue(controlledValue || '')
+    }, [controlledValue, options, children])
 
-  const handleSelection = e => {
-    if (onChange) onChange(e)
-    setSelectedValue(e.target.value)
+    const handleSelection = e => {
+      if (onChange) onChange(e)
+      setSelectedValue(e.target.value)
+    }
+
+    if (!selectedValue) classes.push(placeholder)
+
+    // TODO (jscheel): Currently, SSR does not like when we add an option for some
+    // reason. On first render, it doesn't render the label option that is added
+    // below. We need to figure _why_ SSR is ignoring this on first render.
+    return (
+      <Label text={labelText}>
+        <div css={wrapper}>
+          <select
+            {...rest}
+            css={classes}
+            value={selectedValue}
+            onChange={handleSelection}
+            ref={ref}
+          >
+            <React.Fragment>
+              <option key="__placeholder__" value="" disabled>
+                {labelText}
+              </option>
+              {children ||
+                options.map(
+                  ({
+                    key: optionKey,
+                    value: optionValue,
+                    label: optionLabel,
+                  }) => (
+                    <option key={optionKey || optionValue} value={optionValue}>
+                      {optionLabel}
+                    </option>
+                  )
+                )}
+            </React.Fragment>
+          </select>
+          <Icon icon="arrowDown" size="small" color="stoneGrey" css={[arrow]} />
+        </div>
+      </Label>
+    )
   }
-
-  if (!selectedValue) classes.push(placeholder)
-
-  // TODO (jscheel): Currently, SSR does not like when we add an option for some
-  // reason. On first render, it doesn't render the label option that is added
-  // below. We need to figure _why_ SSR is ignoring this on first render.
-  return (
-    <Label text={labelText}>
-      <div css={wrapper}>
-        <select
-          {...rest}
-          css={classes}
-          value={selectedValue}
-          onChange={handleSelection}
-        >
-          <React.Fragment>
-            <option key="__placeholder__" value="" disabled>
-              {labelText}
-            </option>
-            {children ||
-              options.map(
-                ({
-                  key: optionKey,
-                  value: optionValue,
-                  label: optionLabel,
-                }) => (
-                  <option key={optionKey || optionValue} value={optionValue}>
-                    {optionLabel}
-                  </option>
-                )
-              )}
-          </React.Fragment>
-        </select>
-        <Icon icon="arrowDown" size="small" color="stoneGrey" css={[arrow]} />
-      </div>
-    </Label>
-  )
-}
+)
 
 Select.propTypes = {
   /**

--- a/src/components/Forms/TextArea.js
+++ b/src/components/Forms/TextArea.js
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 
-import { useContext } from 'react'
+import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
 import { css, jsx } from '@emotion/core'
 import { FieldContext } from './Field'
@@ -14,19 +14,21 @@ const multiLineStyle = css`
   padding: 13px ${spacing.padding.small}px;
 `
 
-export const TextArea = ({ label: labelText, ...rest }) => {
-  const fieldCtx = useContext(FieldContext)
-  const classes = [
-    baseStyle,
-    multiLineStyle,
-    getValidationStateStyle(fieldCtx.validationState),
-  ]
-  return (
-    <Label text={labelText}>
-      <textarea {...rest} css={[classes]} placeholder={labelText} />
-    </Label>
-  )
-}
+export const TextArea = React.forwardRef(
+  ({ label: labelText, ...rest }, ref) => {
+    const fieldCtx = useContext(FieldContext)
+    const classes = [
+      baseStyle,
+      multiLineStyle,
+      getValidationStateStyle(fieldCtx.validationState),
+    ]
+    return (
+      <Label text={labelText}>
+        <textarea {...rest} css={[classes]} placeholder={labelText} ref={ref} />
+      </Label>
+    )
+  }
+)
 
 TextArea.propTypes = {
   /**


### PR DESCRIPTION
We want refs to point to the actual form element, instead of all of our
wrappings. This way, you can grab the current ref and do things like
focus, check values, etc.