### PR TITLE
Fix bug in flex container cascading div selector

### DIFF
--- a/src/components/FlexContainer.js
+++ b/src/components/FlexContainer.js
@@ -33,7 +33,7 @@ const StyledFlexContainer = styled.div`
     props.gapHorizontal ? GAP[props.gapHorizontal] : 0}px;
   margin-top: ${props => (props.gapVertical ? GAP[props.gapVertical] : 0)}px;
 
-  div:first-of-type {
+  > div:first-of-type {
     margin-left: 0;
     margin-top: 0;
   }


### PR DESCRIPTION
This fix prevents the div selector from deeply selecting divs.