### PR TITLE
Add container scrollTop setter to container context

### DIFF
--- a/src/components/Container.js
+++ b/src/components/Container.js
@@ -129,6 +129,14 @@ export const Container = ({
     scrollPositionMotionValue.set(scrollTop)
   }, [scrollPositionMotionValue])
 
+  const setScrollTop = useCallback(
+    y => {
+      if (!contentRef.current) return
+      contentRef.current.scrollTop = y
+    },
+    [contentRef]
+  )
+
   const bodyMarginTop = useTransform(scrollPositionMotionValue, scrollRange, [
     padded
       ? -(spacing.padding.large + spacing.padding.small)
@@ -176,6 +184,7 @@ export const Container = ({
         scrollPositionMotionValue,
         headerStubHeight,
         scrollRange,
+        setScrollTop,
       }}
     >
       <StyleContainer {...rest}>

--- a/src/components/ContainerContext.js
+++ b/src/components/ContainerContext.js
@@ -1,9 +1,11 @@
 import React from 'react'
 
 const ContainerContext = React.createContext({
+  overlap: false,
   scrollPositionMotionValue: null,
-  headerStubHeightMotionValue: null,
-  setBodyOffsetRatio: () => {},
+  headerStubHeight: null,
+  scrollRange: [0, 100],
+  setScrollTop: () => {},
 })
 
 export default ContainerContext


### PR DESCRIPTION
This PR adds `setScrollTop` to the container context, so that you can set the scroll position directly, whenever you need to.