### PR TITLE
Fix concatenation of color names when combined with variants

### DIFF
--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
 import { motion } from 'framer-motion'
+import { baseColorName } from '../utils/colors'
 import { color, shadows, spacing } from './shared/styles'
 
 const BORDER_SIZES = {
@@ -42,7 +43,7 @@ const StyledCard = styled(motion.div)`
     cursor: pointer;
     border-color: ${props =>
       props.border && props.borderColor
-        ? color[`${props.borderColor}Hover`]
+        ? color[`${baseColorName(props.borderColor)}Hover`]
         : 'none'};
   }
 `

--- a/src/components/Label.js
+++ b/src/components/Label.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
+import { baseColorName } from '../utils/colors'
 import { spacing, typography } from './shared/styles'
 
 const StyledLabel = styled.div`
@@ -15,16 +16,18 @@ const StyledLabel = styled.div`
 
   a:hover &,
   a:focus & {
-    background: ${props => `var(--color-${props.color}Hover)`} !important;
+    background: ${props =>
+      `var(--color-${baseColorName(props.color)}Hover)`} !important;
   }
 
   a:visited &,
   a:active & {
-    background: ${props => `var(--color-${props.color}Active)`};
+    background: ${props => `var(--color-${baseColorName(props.color)}Active)`};
   }
 
   a:disabled & {
-    background: ${props => `var(--color-${props.color}Disabled)`};
+    background: ${props =>
+      `var(--color-${baseColorName(props.color)}Disabled)`};
   }
 `
 

--- a/src/components/Paragraph.js
+++ b/src/components/Paragraph.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
+import { baseColorName } from '../utils/colors'
 import { typography, spacing } from './shared/styles'
 
 export const PARAGRAPH_SIZES = {
@@ -33,17 +34,17 @@ const StyledParagraph = styled.span`
   a:focus &,
   & a:hover,
   & a:focus {
-    color: ${props => `var(--color-${props.color}Hover)`};
+    color: ${props => `var(--color-${baseColorName(props.color)}Hover)`};
   }
 
   a:active &,
   & a:active {
-    color: ${props => `var(--color-${props.color}Active)`};
+    color: ${props => `var(--color-${baseColorName(props.color)}Active)`};
   }
 
   a:disabled &,
   & a:disabled {
-    color: ${props => `var(--color-${props.color}Disabled)`};
+    color: ${props => `var(--color-${baseColorName(props.color)}Disabled)`};
   }
 `
 

--- a/src/utils/colors.js
+++ b/src/utils/colors.js
@@ -26,3 +26,7 @@ export function contrast(
   if (Color(color).luminosity() < threshold) return light
   return dark
 }
+
+export function baseColorName(color = '') {
+  return color.replace(/(Hover|Active|Disabled)$/, '')
+}


### PR DESCRIPTION
There are a few places where we try to concatenate the color name with
a variant, but this does not work if the color name you pass is already
a variant. For example: `primaryActive` => `primaryActiveHover` which is
not actually a color name. Instead, we now strip any variants out of the
color name that is passed in a prop.