### PR TITLE
Extend configuration options for FlexContainer and FlexItem

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     ]
   },
   "dependencies": {
+    "@emotion/is-prop-valid": "^0.8.8",
     "color": "^3.1.2",
     "framer-motion": "^1.9.1",
     "polished": "^3.4.2",

--- a/src/components/FlexContainer.js
+++ b/src/components/FlexContainer.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import isPropValid from '@emotion/is-prop-valid'
 import styled from '@emotion/styled'
 
 const ALIGNMENT = {
@@ -22,7 +23,10 @@ const GAP = {
   massive: 80,
 }
 
-const StyledFlexContainer = styled.div`
+// https://emotion.sh/docs/styled#changing-based-on-props
+const StyledFlexContainer = styled('div', {
+  shouldForwardProp: prop => isPropValid(prop) && prop !== 'direction',
+})`
   display: ${props => (props.inline ? 'inline-flex' : 'flex')};
   flex-direction: ${props => {
     let dir = props.direction === 'vertical' ? 'column' : 'row'
@@ -48,6 +52,8 @@ export const FlexContainerContext = React.createContext({
   gapHorizontal: undefined,
   gapVertical: undefined,
   reverse: false,
+  stretched: false,
+  direction: 'horizontal',
 })
 
 export const FlexContainer = ({ children, ...rest }) => {
@@ -58,6 +64,8 @@ export const FlexContainer = ({ children, ...rest }) => {
           gapHorizontal: rest.gapHorizontal,
           gapVertical: rest.gapVertical,
           reverse: rest.reverse,
+          stretched: rest.stretched,
+          direction: rest.direction,
         }}
       >
         {children}
@@ -95,6 +103,10 @@ FlexContainer.propTypes = {
    * Specify vertical gap between items
    */
   gapVertical: PropTypes.oneOf(Object.keys(GAP)),
+  /**
+   * Specify if height or width 100% should be applied to the div
+   */
+  stretched: PropTypes.bool,
 }
 
 FlexContainer.defaultProps = {
@@ -105,4 +117,5 @@ FlexContainer.defaultProps = {
   alignVertical: 'start',
   gapHorizontal: undefined,
   gapVertical: undefined,
+  stretched: false,
 }

--- a/src/components/FlexItem.js
+++ b/src/components/FlexItem.js
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
+import isPropValid from '@emotion/is-prop-valid'
 import styled from '@emotion/styled'
 import { FlexContainerContext } from './FlexContainer'
 
@@ -23,24 +24,42 @@ const GAP = {
   massive: '80px',
 }
 
-const StyledFlexItem = styled.div`
-  align-self: ${props => ALIGNMENT[props.align]};
-  flex-grow: ${props => props.grow};
-  flex-shrink: ${props => props.shrink};
-  ${({ reverse, gapHorizontal, gapVertical }) => {
-    const hName = reverse ? 'margin-right' : 'margin-left'
-    const vName = reverse ? 'margin-bottom' : 'margin-top'
-    const hValue = gapHorizontal ? GAP[gapHorizontal] : 0
-    const vValue = gapVertical ? GAP[gapVertical] : 0
-    return `
-      ${hName}: ${hValue};
-      ${vName}: ${vValue};
-    `
-  }}
-`
+// https://emotion.sh/docs/styled#customizing-prop-forwarding
+const StyledFlexItem = styled('div', {
+  shouldForwardProp: prop => isPropValid(prop) && prop !== 'direction',
+})(props => {
+  const hName = props.reverse ? 'margin-right' : 'margin-left'
+  const vName = props.reverse ? 'margin-bottom' : 'margin-top'
+  const hValue = props.gapHorizontal ? GAP[props.gapHorizontal] : 0
+  const vValue = props.gapVertical ? GAP[props.gapVertical] : 0
+  const css = {
+    alignSelf: ALIGNMENT[props.align],
+    flexGrow: props.grow,
+    flexShrink: props.shrink,
+    [hName]: hValue,
+    [vName]: vValue,
+  }
+  if (props.stretched) {
+    if (props.direction === 'horizontal') css.height = '100%'
+    if (props.direction === 'vertical') css.width = '100%'
+  }
+  if (props.minWidth !== null) css.minWidth = props.minWidth
+  return css
+})
 
 export const FlexItem = React.forwardRef(
-  ({ children, gapHorizontal, gapVertical, ...props }, ref) => {
+  (
+    {
+      children,
+      gapHorizontal,
+      gapVertical,
+      stretched,
+      direction,
+      minWidth,
+      ...props
+    },
+    ref
+  ) => {
     const containerContext = useContext(FlexContainerContext)
     return (
       <StyledFlexItem
@@ -48,6 +67,9 @@ export const FlexItem = React.forwardRef(
         gapHorizontal={gapHorizontal || containerContext.gapHorizontal}
         gapVertical={gapVertical || containerContext.gapVertical}
         reverse={containerContext.reverse}
+        stretched={stretched || containerContext.stretched}
+        direction={containerContext.direction}
+        minWidth={minWidth}
         {...props}
       >
         {children}
@@ -77,6 +99,14 @@ FlexItem.propTypes = {
    * Specify vertical gap between items
    */
   gapVertical: PropTypes.oneOf(Object.keys(GAP)),
+  /**
+   * Specify if height or width 100% should be applied to the div
+   */
+  stretched: PropTypes.bool,
+  /**
+   * Specify the min width for this flex item. Defaults to not setting this value
+   */
+  minWidth: PropTypes.number,
 }
 
 FlexItem.defaultProps = {
@@ -85,4 +115,6 @@ FlexItem.defaultProps = {
   shrink: 1,
   gapHorizontal: undefined,
   gapVertical: undefined,
+  stretched: false,
+  minWidth: null,
 }

--- a/src/components/FlexItem.js
+++ b/src/components/FlexItem.js
@@ -104,7 +104,7 @@ FlexItem.propTypes = {
    */
   stretched: PropTypes.bool,
   /**
-   * Specify the min width for this flex item. Defaults to not setting this value
+   * Specify the min width for this flex item
    */
   minWidth: PropTypes.number,
 }

--- a/src/components/Paragraph.js
+++ b/src/components/Paragraph.js
@@ -49,9 +49,9 @@ const StyledParagraph = styled.span`
   }
 `
 
-export const Paragraph = React.forwardRef((props, forwardedRef) => (
-  <StyledParagraph {...props} ref={forwardedRef} />
-))
+export const Paragraph = React.forwardRef(({ as, ...props }, forwardedRef) => {
+  return <StyledParagraph {...props} as={as} ref={forwardedRef} />
+})
 
 Paragraph.propTypes = {
   /**
@@ -82,6 +82,10 @@ Paragraph.propTypes = {
    * Whether it is padded
    */
   padded: PropTypes.bool,
+  /**
+   * Component to render as defaults span
+   */
+  as: PropTypes.elementType,
 }
 
 Paragraph.defaultProps = {
@@ -92,4 +96,5 @@ Paragraph.defaultProps = {
   align: ALIGNMENT.left,
   inline: false,
   padded: true,
+  as: 'span',
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,6 +1044,13 @@
   dependencies:
     "@emotion/memoize" "0.7.4"
 
+"@emotion/is-prop-valid@^0.8.8":
+  version "0.8.8"
+  resolved "https://package-cluster.production.groovehq.com/@emotion%2fis-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
 "@emotion/memoize@0.7.4":
   version "0.7.4"
   resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"


### PR DESCRIPTION
FIX: Direction prop no longer forwarded to dom for FlexContainer and FlexItem
NEW: Created streched prop which indicates to the flexbox that it should add width:100% or height:100% depending on direction
NEW: Add minWidth option to FlexItem which allows specifying the minWidth
NEW: Extend the paragraph component to support the as property