### PR TITLE
Fix badge centering

### DIFF
--- a/src/components/Badge.js
+++ b/src/components/Badge.js
@@ -27,6 +27,7 @@ const StyledBadge = styled.div`
   box-sizing: border-box;
   display: inline-flex;
   align-items: center;
+  vertical-align: middle;
   user-select: none;
   cursor: pointer;
   outline: none;


### PR DESCRIPTION
The badge's vertical position was not consistent in all variations of icon and text display.